### PR TITLE
add support for checkout captures endpoint

### DIFF
--- a/src/Adyen/Service/Checkout.php
+++ b/src/Adyen/Service/Checkout.php
@@ -70,6 +70,11 @@ class Checkout extends \Adyen\ApiKeyAuthenticatedService
     protected $reversals;
 
     /**
+     * @var ResourceModel\Checkout\Captures
+     */
+    protected $captures;
+
+    /**
      * Checkout constructor.
      *
      * @param \Adyen\Client $client
@@ -91,6 +96,7 @@ class Checkout extends \Adyen\ApiKeyAuthenticatedService
         $this->sessions = new \Adyen\Service\ResourceModel\Checkout\Sessions($this);
         $this->refunds = new \Adyen\Service\ResourceModel\Checkout\Refunds($this);
         $this->reversals = new \Adyen\Service\ResourceModel\Checkout\Reversals($this);
+        $this->captures = new \Adyen\Service\ResourceModel\Checkout\Captures($this);
     }
 
     /**
@@ -236,5 +242,16 @@ class Checkout extends \Adyen\ApiKeyAuthenticatedService
     public function reversals($params, $requestOptions = null)
     {
         return $this->reversals->request($params, $requestOptions);
+    }
+
+    /**
+     * @param array $params
+     * @param array|null $requestOptions
+     * @return mixed
+     * @throws \Adyen\AdyenException
+     */
+    public function captures($params, $requestOptions = null)
+    {
+        return $this->captures->request($params, $requestOptions);
     }
 }

--- a/src/Adyen/Service/ResourceModel/Checkout/Captures.php
+++ b/src/Adyen/Service/ResourceModel/Checkout/Captures.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Adyen\Service\ResourceModel\Checkout;
+
+class Captures extends \Adyen\Service\AbstractCheckoutResource
+{
+    /**
+     * @var string
+     */
+    protected $endpoint;
+
+    /**
+     * Include applicationInfo key in the request parameters
+     *
+     * @var bool
+     */
+    protected $allowApplicationInfo = false;
+
+    /**
+     * Payments constructor.
+     *
+     * @param \Adyen\Service $service
+     * @throws \Adyen\AdyenException
+     */
+    public function __construct($service)
+    {
+        $this->endpoint = $this->getCheckoutEndpoint($service) .
+            '/' . $service->getClient()->getApiCheckoutVersion() . '/payments/{paymentPspReference}/captures';
+        parent::__construct($service, $this->endpoint, $this->allowApplicationInfo);
+    }
+}

--- a/tests/Integration/CheckoutTest.php
+++ b/tests/Integration/CheckoutTest.php
@@ -358,4 +358,28 @@ class CheckoutTest extends TestCase
 
         $this->assertEquals('received', $result['status']);
     }
+
+    public function testCaptures()
+    {
+        $this->testPaymentsSuccess();
+
+        // create Checkout client
+        $client = $this->createCheckoutAPIClient();
+
+        // initialize service
+        $service = new \Adyen\Service\Checkout($client);
+
+        $params = array(
+            'paymentPspReference' => $this->pspReference,
+            'merchantAccount' => $this->merchantAccount,
+            'amount' => [
+                'currency' => "EUR",
+                'value' => 1000
+            ]
+        );
+
+        $result = $service->captures($params);
+
+        $this->assertEquals('received', $result['status']);
+    }
 }


### PR DESCRIPTION
**Description**
Added v68 Checkout method implementation for:

- POST [/payments/{paymentPspReference}/captures](https://docs.adyen.com/api-explorer/#/CheckoutService/v68/post/payments/{paymentPspReference}/captures)

**Tested scenarios**
Integration checks:
- \Adyen\Tests\Integration\CheckoutTest::testCaptures
