### PR TITLE
support for checkout cancels

### DIFF
--- a/src/Adyen/Service/Checkout.php
+++ b/src/Adyen/Service/Checkout.php
@@ -75,6 +75,11 @@ class Checkout extends \Adyen\ApiKeyAuthenticatedService
     protected $captures;
 
     /**
+     * @var ResourceModel\Checkout\Cancels
+     */
+    protected $cancels;
+
+    /**
      * Checkout constructor.
      *
      * @param \Adyen\Client $client
@@ -97,6 +102,7 @@ class Checkout extends \Adyen\ApiKeyAuthenticatedService
         $this->refunds = new \Adyen\Service\ResourceModel\Checkout\Refunds($this);
         $this->reversals = new \Adyen\Service\ResourceModel\Checkout\Reversals($this);
         $this->captures = new \Adyen\Service\ResourceModel\Checkout\Captures($this);
+        $this->cancels = new \Adyen\Service\ResourceModel\Checkout\Cancels($this);
     }
 
     /**
@@ -253,5 +259,16 @@ class Checkout extends \Adyen\ApiKeyAuthenticatedService
     public function captures($params, $requestOptions = null)
     {
         return $this->captures->request($params, $requestOptions);
+    }
+
+    /**
+     * @param array $params
+     * @param array|null $requestOptions
+     * @return mixed
+     * @throws \Adyen\AdyenException
+     */
+    public function cancels($params, $requestOptions = null)
+    {
+        return $this->cancels->request($params, $requestOptions);
     }
 }

--- a/src/Adyen/Service/ResourceModel/Checkout/Cancels.php
+++ b/src/Adyen/Service/ResourceModel/Checkout/Cancels.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Adyen\Service\ResourceModel\Checkout;
+
+class Cancels extends \Adyen\Service\AbstractCheckoutResource
+{
+    /**
+     * @var string
+     */
+    protected $endpoint;
+
+    /**
+     * Include applicationInfo key in the request parameters
+     *
+     * @var bool
+     */
+    protected $allowApplicationInfo = false;
+
+    /**
+     * Payments constructor.
+     *
+     * @param \Adyen\Service $service
+     * @throws \Adyen\AdyenException
+     */
+    public function __construct($service)
+    {
+        $this->endpoint = $this->getCheckoutEndpoint($service) .
+            '/' . $service->getClient()->getApiCheckoutVersion() . '/payments/{paymentPspReference}/cancels';
+        parent::__construct($service, $this->endpoint, $this->allowApplicationInfo);
+    }
+}

--- a/tests/Integration/CheckoutTest.php
+++ b/tests/Integration/CheckoutTest.php
@@ -382,4 +382,24 @@ class CheckoutTest extends TestCase
 
         $this->assertEquals('received', $result['status']);
     }
+
+    public function testCancels()
+    {
+        $this->testPaymentsSuccess();
+
+        // create Checkout client
+        $client = $this->createCheckoutAPIClient();
+
+        // initialize service
+        $service = new \Adyen\Service\Checkout($client);
+
+        $params = array(
+            'paymentPspReference' => $this->pspReference,
+            'merchantAccount' => $this->merchantAccount,
+        );
+
+        $result = $service->cancels($params);
+
+        $this->assertEquals('received', $result['status']);
+    }
 }


### PR DESCRIPTION
Description
Added v68 Checkout method implementation for:

- POST [/payments/{paymentPspReference}/cancels](https://docs.adyen.com/api-explorer/#/CheckoutService/v68/post/payments/%7BpaymentPspReference%7D/cancels)

Tested scenarios
Integration checks:

- \Adyen\Tests\Integration\CheckoutTest::testCancels